### PR TITLE
[PAPI-325] Backfill Token Attributes

### DIFF
--- a/pipeline-scripts/create-database.sql
+++ b/pipeline-scripts/create-database.sql
@@ -28,7 +28,6 @@ CREATE PROCEDURE CreateDatabase ()
         (
             Id            BIGINT UNSIGNED AUTO_INCREMENT,
             Address       VARCHAR(50)     NOT NULL,
-            IsLpt         BIT DEFAULT 0   NOT NULL,
             Symbol        VARCHAR(20)     CHARACTER SET utf16 NOT NULL COLLATE utf16_general_ci,
             Name          VARCHAR(50)     CHARACTER SET utf16 NOT NULL COLLATE utf16_general_ci,
             Decimals      SMALLINT        NOT NULL,
@@ -40,7 +39,6 @@ CREATE PROCEDURE CreateDatabase ()
             UNIQUE token_address_uq (Address),
             INDEX token_symbol_ix (Symbol),
             INDEX token_name_ix (Name),
-            INDEX token_is_lpt_ix (IsLpt),
             CONSTRAINT token_created_block_block_height_fk
                 FOREIGN KEY (CreatedBlock)
                 REFERENCES block (Height),
@@ -422,7 +420,7 @@ CREATE PROCEDURE CreateDatabase ()
 
         CREATE TABLE IF NOT EXISTS token_attribute
         (
-            Id              SMALLINT UNSIGNED NOT NULL,
+            Id              BIGINT UNSIGNED AUTO_INCREMENT,
             TokenId         BIGINT UNSIGNED   NOT NULL,
             AttributeTypeId SMALLINT UNSIGNED NOT NULL,
             PRIMARY KEY (Id),

--- a/scripts/PAPI-325_TokenAttributesBackfill.sql
+++ b/scripts/PAPI-325_TokenAttributesBackfill.sql
@@ -1,0 +1,46 @@
+DELIMITER //
+
+CREATE PROCEDURE TokenAttributesBackfill ()
+ BEGIN
+    SELECT COUNT(*) into @exists
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA='platform'
+        AND TABLE_NAME='token'
+        AND column_name='IsLpt';
+
+    IF @exists > 0 THEN
+        ALTER TABLE token_attribute MODIFY Id BIGINT UNSIGNED AUTO_INCREMENT;
+
+        INSERT IGNORE INTO token_attribute(TokenId, AttributeTypeId)
+            (
+                SELECT Id, (SELECT Id  FROM token_attribute_type WHERE AttributeType = 'Provisional') as AttributeTypeId
+                FROM token
+                WHERE IsLpt = true
+            );
+
+        INSERT IGNORE INTO token_attribute(TokenId, AttributeTypeId)
+            (
+                SELECT Id, (SELECT Id  FROM token_attribute_type WHERE AttributeType = 'NonProvisional') as AttributeTypeId
+                FROM token
+                WHERE IsLpt = false
+            );
+
+        INSERT IGNORE INTO token_attribute(TokenId, AttributeTypeId)
+            (
+                SELECT StakingTokenId as Id, (SELECT Id  FROM token_attribute_type WHERE AttributeType = 'Staking') as AttributeTypeId
+                FROM market
+                WHERE StakingTokenId > 0
+            );
+
+        ALTER TABLE token DROP COLUMN IsLpt;
+    END IF;
+ END;
+//
+
+CALL TokenAttributesBackfill();
+//
+
+DROP PROCEDURE TokenAttributesBackfill;
+//
+
+DELIMITER ;


### PR DESCRIPTION
- Removes `token.IsLpt` column
- Adjusts `token_attribute.Id` to be bigint with auto increment
- Backfill `token_attribute` values